### PR TITLE
Fix scenario 40

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+version 1.0.4.23
+- Prevent Aethra from not get killed in scenario 40.
+
 version 1.0.4.17
 - Fixed specials of Ryujin Tensho last upgrade being appended instead of replacing the old ones.
 - Fixed Algil not being unstore in scenario 33.

--- a/scenarios/40_Tides_Of_Destruction.cfg
+++ b/scenarios/40_Tides_Of_Destruction.cfg
@@ -95,6 +95,7 @@
         [/unit]
 
         {FORCE_CHANCE_TO_HIT side=2 id=Aetheryon 20 ()}
+        {FORCE_CHANCE_TO_HIT side=2 id=Aethra 100 ()}
 
         {NAMED_LOYAL_UNIT 2 (Arch Mage) 8 3 (Fethanir) ("Master Fethanir")} {GUARDIAN}
         {NAMED_LOYAL_UNIT 2 (Iron Mauler) 4 8 (Ruddryn) ("Ruddryn")} {GUARDIAN}
@@ -107,62 +108,6 @@
         {PLACE_IMAGE items/iron-banner.png   8 5}
         {PLACE_IMAGE items/iron-banner.png   4 7}
         {PLACE_IMAGE items/iron-banner.png   8 7}
-
-        # To prevent Aetheryon from not appearing...
-
-        [if]
-            [not]
-                [have_unit]
-                    id=Aetheryon
-                [/have_unit]
-            [/not]
-            [then]
-                [unit]
-                    {AETHERYON_MASTER}
-                    side=1
-                    x,y=6,12
-                [/unit]
-
-                [object]
-                    id=special_attacks
-                    duration=forever
-                    silent=yes
-                    [filter]
-                        id=Aetheryon
-                    [/filter]
-                    [effect]
-                        apply_to=new_attack
-                        name=ringfire
-                        description= _"Ring of Fire"
-                        type=fire
-                        range=ranged
-                        damage=30
-                        number=1
-                        [specials]
-                            {WEAPON_SPECIAL_MARKSMAN}
-                            {WEAPON_SPECIAL_ATTACK_ONLY}
-                            {WEAPON_SPECIAL_WHIRLWIND}
-                        [/specials]
-                        icon=attacks/ringfire.png
-                    [/effect]
-                    [effect]
-                        apply_to=new_attack
-                        name=blizzard
-                        description= _"Blizzard"
-                        type=cold
-                        range=ranged
-                        damage=30
-                        number=1
-                        [specials]
-                            {WEAPON_SPECIAL_MARKSMAN}
-                            {WEAPON_SPECIAL_ATTACK_ONLY}
-                            {WEAPON_SPECIAL_EXPLOSIVE}
-                        [/specials]
-                        icon=attacks/blizzard.png
-                    [/effect]
-                [/object]
-            [/then]
-        [/if]
 
         [hide_unit]
             id=Tenma

--- a/scenarios/40_Tides_Of_Destruction.cfg
+++ b/scenarios/40_Tides_Of_Destruction.cfg
@@ -95,7 +95,6 @@
         [/unit]
 
         {FORCE_CHANCE_TO_HIT side=2 id=Aetheryon 20 ()}
-        {FORCE_CHANCE_TO_HIT side=2 id=Aethra 100 ()}
 
         {NAMED_LOYAL_UNIT 2 (Arch Mage) 8 3 (Fethanir) ("Master Fethanir")} {GUARDIAN}
         {NAMED_LOYAL_UNIT 2 (Iron Mauler) 4 8 (Ruddryn) ("Ruddryn")} {GUARDIAN}
@@ -214,6 +213,14 @@
         [filter]
             id=Aethra
         [/filter]
+
+        [fire_event]
+            name=aethra_dies
+        [/fire_event]
+    [/event]
+
+    [event]
+        name=side 2 turn end, aethra_dies
 
         [message]
             speaker=Aethra

--- a/scenarios/48_The_Sun_Sets_Over_Wesnoth.cfg
+++ b/scenarios/48_The_Sun_Sets_Over_Wesnoth.cfg
@@ -4,7 +4,7 @@
 
 [scenario]
     id=48_The_Sun_Sets_Over_Wesnoth
-    name= _ "The Sun sets over Wesnoth"
+    name= _ "The Sun Sets over Wesnoth"
     next_scenario=49_The_Children_Of_Demere
     map_data="{~add-ons/Aria_of_the_Dragon_Slayer/maps/48_The_Sun_Sets_Over_Wesnoth.map}"
     turns=-1


### PR DESCRIPTION
Guards could fail at killing Aethra. If you would then kill the emperor, it would then break the campaign.
This PR fixes the issue by triggering the event at the end of side 2 turn if Aethra is still alive. 